### PR TITLE
Add --no-build to deploy to prevent building on server

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,7 +64,7 @@ jobs:
           script: |
             cd /home/deploy/ditto
             docker compose -f docker-compose.prod.yml pull backend frontend
-            docker compose -f docker-compose.prod.yml up -d
+            docker compose -f docker-compose.prod.yml up -d --no-build
 
       - name: Wait for services to start
         run: sleep 30


### PR DESCRIPTION
## Summary
- Server only has docker-compose.prod.yml, not source code
- `docker compose up -d` tries to build when `build:` directive is present
- Adding `--no-build` forces it to use pulled images only

## Test plan
- [ ] Deploy workflow successfully starts containers on server