### PR TITLE
Disable GHCR provenance attestations to fix image pull

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           context: ./backend
           push: true
+          provenance: false
           tags: |
             ${{ env.REGISTRY }}/ditto-backend:latest
             ${{ env.REGISTRY }}/ditto-backend:${{ github.sha }}
@@ -44,6 +45,7 @@ jobs:
         with:
           context: ./frontend
           push: true
+          provenance: false
           tags: |
             ${{ env.REGISTRY }}/ditto-frontend:latest
             ${{ env.REGISTRY }}/ditto-frontend:${{ github.sha }}


### PR DESCRIPTION
## Summary
- `docker/build-push-action@v6` adds provenance attestations by default on public repos
- This creates a multi-manifest image index that causes `not found` errors on pull
- Setting `provenance: false` pushes standard single-manifest images

## References
- https://github.com/docker/build-push-action/pull/781
- https://github.com/orgs/community/discussions/45969

## Test plan
- [ ] Images pull successfully on server after push