### PR TITLE
Use plain docker push to fix GHCR image availability

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,27 +28,19 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push backend
-        uses: docker/build-push-action@v6
-        with:
-          context: ./backend
-          push: true
-          provenance: false
-          tags: |
-            ${{ env.REGISTRY }}/ditto-backend:latest
-            ${{ env.REGISTRY }}/ditto-backend:${{ github.sha }}
+        run: |
+          docker build -t ${{ env.REGISTRY }}/ditto-backend:latest -t ${{ env.REGISTRY }}/ditto-backend:${{ github.sha }} ./backend
+          docker push ${{ env.REGISTRY }}/ditto-backend:latest
+          docker push ${{ env.REGISTRY }}/ditto-backend:${{ github.sha }}
 
       - name: Create frontend production env
         run: echo "NEXT_PUBLIC_API_URL=https://${{ secrets.DEPLOY_DOMAIN }}" > frontend/.env.production
 
       - name: Build and push frontend
-        uses: docker/build-push-action@v6
-        with:
-          context: ./frontend
-          push: true
-          provenance: false
-          tags: |
-            ${{ env.REGISTRY }}/ditto-frontend:latest
-            ${{ env.REGISTRY }}/ditto-frontend:${{ github.sha }}
+        run: |
+          docker build -t ${{ env.REGISTRY }}/ditto-frontend:latest -t ${{ env.REGISTRY }}/ditto-frontend:${{ github.sha }} ./frontend
+          docker push ${{ env.REGISTRY }}/ditto-frontend:latest
+          docker push ${{ env.REGISTRY }}/ditto-frontend:${{ github.sha }}
 
   deploy:
     name: Deploy to Production


### PR DESCRIPTION
## Summary
- Replace docker/build-push-action with plain `docker build` + `docker push`
- build-push-action uses buildkit which may create image manifests GHCR can't serve
- Plain docker push creates standard v2 manifests that always work

## Test plan
- [ ] Images available for pull after push
- [ ] Server deploys successfully