### PR TITLE
Switch deploy to build images on server instead of GHCR

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,56 +9,32 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build-and-push:
-    name: Build & Push Images
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set image registry
-        run: echo "REGISTRY=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"
-
-      - uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push backend
-        run: |
-          docker build -t ${{ env.REGISTRY }}/ditto-backend:latest -t ${{ env.REGISTRY }}/ditto-backend:${{ github.sha }} ./backend
-          docker push ${{ env.REGISTRY }}/ditto-backend:latest
-          docker push ${{ env.REGISTRY }}/ditto-backend:${{ github.sha }}
-
-      - name: Create frontend production env
-        run: echo "NEXT_PUBLIC_API_URL=https://${{ secrets.DEPLOY_DOMAIN }}" > frontend/.env.production
-
-      - name: Build and push frontend
-        run: |
-          docker build -t ${{ env.REGISTRY }}/ditto-frontend:latest -t ${{ env.REGISTRY }}/ditto-frontend:${{ github.sha }} ./frontend
-          docker push ${{ env.REGISTRY }}/ditto-frontend:latest
-          docker push ${{ env.REGISTRY }}/ditto-frontend:${{ github.sha }}
-
   deploy:
     name: Deploy to Production
-    needs: build-and-push
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Deploy via SSH
+      - name: Copy source to server
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          source: "backend/,frontend/,docker-compose.prod.yml,Caddyfile"
+          target: /home/${{ secrets.SSH_USER }}/ditto
+
+      - name: Create frontend env and deploy
         uses: appleboy/ssh-action@v1
         with:
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |
-            cd /home/deploy/ditto
-            docker compose -f docker-compose.prod.yml pull backend frontend
-            docker compose -f docker-compose.prod.yml up -d --no-build
+            cd /home/${{ secrets.SSH_USER }}/ditto
+            echo "NEXT_PUBLIC_API_URL=https://${{ secrets.DEPLOY_DOMAIN }}" > frontend/.env.production
+            docker compose -f docker-compose.prod.yml build backend frontend
+            docker compose -f docker-compose.prod.yml up -d
 
       - name: Wait for services to start
         run: sleep 30

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -17,7 +17,6 @@ services:
       - ditto-network
 
   backend:
-    image: ghcr.io/simononenineight/ditto-backend:latest
     build:
       context: ./backend
       dockerfile: Dockerfile
@@ -46,7 +45,6 @@ services:
       - ditto-network
 
   frontend:
-    image: ghcr.io/${GITHUB_REPOSITORY_OWNER}/ditto-frontend:latest
     build:
       context: ./frontend
       dockerfile: Dockerfile


### PR DESCRIPTION
## Summary
- Replace GHCR push/pull workflow with SCP + build-on-server approach
- Remove `image:` GHCR references from docker-compose.prod.yml
- Deploy now copies source to server via SCP, builds Docker images there, then starts services

## Context
GHCR image pull consistently returned "not found" despite successful pushes and public package visibility. Building on the server is simpler and eliminates the registry dependency entirely.

## Test plan
- [ ] Merge to main and verify deploy workflow triggers
- [ ] Verify SCP copies source files to server
- [ ] Verify docker compose build succeeds on server
- [ ] Verify smoke tests pass (health endpoint, frontend, HTTPS)