### PR TITLE
Fix GHCR push: add buildx setup and OCI labels

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,6 +23,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
@@ -35,7 +38,10 @@ jobs:
         with:
           context: ./backend
           push: true
+          provenance: false
           tags: ${{ env.BACKEND_IMAGE }}:latest
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
 
       - name: Create frontend env
         run: echo "NEXT_PUBLIC_API_URL=https://${{ secrets.DEPLOY_DOMAIN }}" > frontend/.env.production
@@ -45,7 +51,10 @@ jobs:
         with:
           context: ./frontend
           push: true
+          provenance: false
           tags: ${{ env.FRONTEND_IMAGE }}:latest
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
 
       - name: Copy config to server
         uses: appleboy/scp-action@v0.1.7


### PR DESCRIPTION
## Summary
- Add `docker/setup-buildx-action@v3` (required by build-push-action v6)
- Disable provenance attestations (known to cause issues with GHCR)
- Add OCI source labels to link packages to this repository

Fixes "owner not found" error from #47. Also changed repo workflow permissions from read to read-write.