### PR TITLE
Switch CI/CD to docker save + SCP (bypass GHCR)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,55 +8,28 @@ concurrency:
   group: deploy
   cancel-in-progress: false
 
-permissions:
-  contents: read
-  packages: write
-
-env:
-  BACKEND_IMAGE: ghcr.io/simononenineight/ditto-backend
-  FRONTEND_IMAGE: ghcr.io/simononenineight/ditto-frontend
-
 jobs:
   build-and-deploy:
-    name: Build, Push & Deploy
+    name: Build & Deploy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push backend
-        uses: docker/build-push-action@v6
-        with:
-          context: ./backend
-          push: true
-          provenance: false
-          tags: ${{ env.BACKEND_IMAGE }}:latest
-          labels: |
-            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+      - name: Build backend image
+        run: docker build -t ditto-backend:latest ./backend
 
       - name: Create frontend env
         run: echo "NEXT_PUBLIC_API_URL=https://${{ secrets.DEPLOY_DOMAIN }}" > frontend/.env.production
 
-      - name: Build and push frontend
-        uses: docker/build-push-action@v6
-        with:
-          context: ./frontend
-          push: true
-          provenance: false
-          tags: ${{ env.FRONTEND_IMAGE }}:latest
-          labels: |
-            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+      - name: Build frontend image
+        run: docker build -t ditto-frontend:latest ./frontend
 
-      - name: Copy config to server
+      - name: Save and compress images
+        run: |
+          docker save ditto-backend:latest | gzip > /tmp/ditto-backend.tar.gz
+          docker save ditto-frontend:latest | gzip > /tmp/ditto-frontend.tar.gz
+
+      - name: Copy images and config to server
         uses: appleboy/scp-action@v0.1.7
         with:
           host: ${{ secrets.SSH_HOST }}
@@ -65,15 +38,27 @@ jobs:
           source: "scripts/,docker-compose.prod.yml,Caddyfile"
           target: /home/${{ secrets.SSH_USER }}/ditto
 
-      - name: Pull images and restart
+      - name: Copy image archives to server
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          source: "/tmp/ditto-backend.tar.gz,/tmp/ditto-frontend.tar.gz"
+          target: /tmp
+          strip_components: 1
+
+      - name: Load images and restart
         uses: appleboy/ssh-action@v1
         with:
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |
+            gzip -dc /tmp/ditto-backend.tar.gz | docker load
+            gzip -dc /tmp/ditto-frontend.tar.gz | docker load
+            rm -f /tmp/ditto-backend.tar.gz /tmp/ditto-frontend.tar.gz
             cd /home/${{ secrets.SSH_USER }}/ditto
-            docker compose -f docker-compose.prod.yml pull backend frontend
             docker compose -f docker-compose.prod.yml up -d
 
       - name: Wait for services to start

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -17,7 +17,8 @@ services:
       - ditto-network
 
   backend:
-    image: ghcr.io/simononenineight/ditto-backend:latest
+    image: ditto-backend:latest
+    pull_policy: never
     restart: unless-stopped
     environment:
       DATABASE_URL: postgres://${DB_USER}:${DB_PASSWORD}@db:5432/${DB_NAME}?sslmode=disable
@@ -43,7 +44,8 @@ services:
       - ditto-network
 
   frontend:
-    image: ghcr.io/simononenineight/ditto-frontend:latest
+    image: ditto-frontend:latest
+    pull_policy: never
     restart: unless-stopped
     environment:
       NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL}


### PR DESCRIPTION
## Summary
- GHCR namespace is broken ("owner not found" on all push attempts)
- Build Docker images in GitHub Actions runner instead of on the 2GB server
- Ship compressed images via SCP (`docker save | gzip` → `docker load`)
- No registry dependency — images go directly from Actions runner to server

## How it works
1. `docker build` backend and frontend on ubuntu-latest runner
2. `docker save | gzip` to compress (~11MB backend, ~50MB frontend)
3. SCP archives + config files to server
4. `docker load` on server, then `docker compose up -d`

## When GHCR is fixed
Replace with `docker compose pull` from GHCR — one workflow change.