### PR TITLE
Fix application file uploads and show existing attachments

### DIFF
--- a/frontend/src/app/(app)/applications/[id]/page.tsx
+++ b/frontend/src/app/(app)/applications/[id]/page.tsx
@@ -42,6 +42,7 @@ import {
 } from '@/services/assessment-service';
 import { AssessmentList } from '@/components/assessment-list';
 import { AssessmentFormModal } from '@/components/assessment-form';
+import { DocumentsSection } from '@/components/file-upload';
 
 const statusVariantMap: Record<string, 'applied' | 'screening' | 'interviewing' | 'offered' | 'rejected' | 'withdrawn' | 'default'> = {
     'Applied': 'applied',
@@ -490,6 +491,13 @@ const ApplicationPage = () => {
                                     );
                                 }}
                             />
+                        </CardContent>
+                    </Card>
+
+                    {/* Documents card */}
+                    <Card>
+                        <CardContent className="p-4 md:p-5">
+                            <DocumentsSection applicationId={applicationId} title="Documents" />
                         </CardContent>
                     </Card>
                 </div>

--- a/frontend/src/app/(app)/applications/new/__tests__/add-application-form.test.tsx
+++ b/frontend/src/app/(app)/applications/new/__tests__/add-application-form.test.tsx
@@ -72,6 +72,7 @@ jest.mock("../company-autocomplete", () => ({
 
 jest.mock("@/components/file-upload", () => ({
   FileUpload: () => <div data-testid="file-upload" />,
+  DocumentsSection: () => <div data-testid="documents-section" />,
 }));
 
 jest.mock("@/components/ui/select", () => ({

--- a/frontend/src/app/(app)/applications/new/add-application-form.tsx
+++ b/frontend/src/app/(app)/applications/new/add-application-form.tsx
@@ -28,7 +28,7 @@ const RichTextEditor = dynamic(
     () => import('@/components/rich-text-editor').then((mod) => ({ default: mod.RichTextEditor })),
     { loading: () => <Skeleton className="h-[150px] w-full rounded-lg" />, ssr: false }
 );
-import { FileUpload } from '@/components/file-upload';
+import { FileUpload, DocumentsSection } from '@/components/file-upload';
 import {
     getPresignedUploadUrl,
     uploadToS3,
@@ -182,7 +182,7 @@ const ApplicationForm = ({
                         max_salary: data.maxSalary ? parseFloat(data.maxSalary) : undefined,
                     }
                 );
-                resultApplicationId = response.data?.data?.id;
+                resultApplicationId = response.data?.data?.application?.id;
             }
 
             // Upload pending file if exists
@@ -395,7 +395,11 @@ const ApplicationForm = ({
 
             <FormFieldWrapper>
                 <FormLabel className="mb-2">Attachments</FormLabel>
-                <FileUpload onFileSelect={setPendingFile} />
+                {mode === 'edit' && applicationId ? (
+                    <DocumentsSection applicationId={applicationId} />
+                ) : (
+                    <FileUpload onFileSelect={setPendingFile} />
+                )}
             </FormFieldWrapper>
 
             <div className="flex flex-col-reverse sm:flex-row sm:justify-end items-stretch sm:items-center gap-3 mt-12 pt-6">


### PR DESCRIPTION
## Summary
- **Fix create-mode file upload**: The `quick-create` API response nests the application ID under `data.application.id`, but the code was reading `data.id` — so `resultApplicationId` was always `undefined` and the upload step was silently skipped
- **Show existing files in edit mode**: Replace bare `FileUpload` with `DocumentsSection` when editing, so users can see, download, and delete existing attachments
- **Add Documents card to detail page**: Users can now view attached files without entering edit mode

## Test plan
- [ ] Create a new application with a file attachment — toast should say "Application saved with document"
- [ ] View the application detail page — Documents section shows the uploaded file
- [ ] Edit an existing application — Attachments section lists existing files with download/delete
- [ ] Upload a new file from edit mode — file uploads immediately and appears in the list
- [ ] Create a new application without a file — existing behavior unchanged