### PR TITLE
Add www subdomain SSL support

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,4 +1,4 @@
-{$DOMAIN:localhost} {
+{$DOMAIN:localhost}, www.{$DOMAIN:localhost} {
     encode gzip
 
     header {


### PR DESCRIPTION
## Summary
- Add `www.jobditto.com` to the Caddyfile so Caddy auto-provisions SSL for the www subdomain
- Visitors hitting `www.jobditto.com` will no longer see SSL errors

## Test plan
- [ ] Ensure DNS A record for `www` points to 5.78.181.61
- [ ] After deploy, verify `https://www.jobditto.com` loads without SSL errors
